### PR TITLE
Fix retrieval URL generation when params are omitted

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -106,5 +106,5 @@ export function retrieval(endpoint: string, params?: json) {
     const query = new URLSearchParams(params).toString();
     return `${urlChecker(endpoint)}?${query}`;
   }
-  return urlChecker("endpoint");
+  return urlChecker(endpoint);
 }


### PR DESCRIPTION
### Motivation
- Fix `retrieval` so the no-params branch returns `urlChecker(endpoint)` instead of the literal `"endpoint"`, restoring correct URL generation.

### Description
- Replaced the incorrect `return urlChecker("endpoint");` with `return urlChecker(endpoint);` in `src/utils/api.ts` so calls like `retrieval("foo")` produce the expected URL.

### Testing
- Ran a search for `retrieval(` in the codebase and executed `npm run build`, both completing successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4c82ca4b883298355475dade2b0b1)