### PR TITLE
06-11-26  6:46 [feat: ano ba purpose nito]

### DIFF
--- a/src/components/ai.svelte
+++ b/src/components/ai.svelte
@@ -7,6 +7,7 @@
 		expr = [],
 		projects = [],
 		blogs = [],
+		achievements = [],
 		wakatime = {},
 		parseData = false,
 	} = $props();
@@ -20,6 +21,7 @@
 		nicknames: ["Kim", "Ryann", "Kimmy"],
 		weekly_activity: wakatime,
 		expriences: expr,
+		achievements: achievements,
 		alias: ["RyannKim327", "RySes", "RySes Malabanan", "Krysanne Guinmods"],
 		birthyear: 2001,
 		sex: "male",

--- a/src/routes/admin/contact.svelte
+++ b/src/routes/admin/contact.svelte
@@ -13,7 +13,7 @@
   ];
 </script>
 
-<div class="min-h-screen w-full flex items-center justify-center p-6 pt-20">
+<div class="h-full w-full flex items-center justify-center p-6 pt-20">
   <div
     class="w-full max-w-4xl rounded-2xl border border-zinc-800 bg-zinc-50 dark:bg-zinc-900/70 backdrop-blur-xl shadow-2xl p-8 flex flex-col h-[80vh] overflow-hidden"
   >

--- a/src/routes/admin/info.svelte
+++ b/src/routes/admin/info.svelte
@@ -7,7 +7,7 @@
 	let content = $state("");
 </script>
 
-<div class="min-h-screen w-full flex items-center justify-center p-6 pt-20">
+<div class="h-full w-full flex items-center justify-center p-6 pt-20">
 	<div
 		class="w-full max-w-7xl rounded-2xl border border-zinc-800 bg-zinc-50 dark:bg-zinc-900/70 backdrop-blur-xl shadow-2xl p-8 flex flex-col md:flex-row h-[85vh] gap-8 overflow-hidden"
 	>

--- a/src/routes/admin/upload.svelte
+++ b/src/routes/admin/upload.svelte
@@ -49,7 +49,7 @@
 	}
 </script>
 
-<div class="min-h-screen w-full flex items-center justify-center p-6">
+<div class="h-full w-full flex items-center justify-center p-6">
 	<div
 		class="w-full max-w-2xl rounded border border-zinc-800 backdrop-blur-xl shadow-2xl p-8"
 	>

--- a/src/routes/home/achievements.svelte
+++ b/src/routes/home/achievements.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-
 </script>
 
 <div class="">

--- a/src/routes/home/contact.svelte
+++ b/src/routes/home/contact.svelte
@@ -30,7 +30,7 @@
 
 <div
 	id="contact"
-	class="flex flex-col p-2 pt-[25%] md:pt-[7%] w-full h-full gap-2 overflow-hidden overflow-y-auto snap-start justify-between"
+	class="flex flex-col p-2 pt-[25%] md:pt-[7%] w-full h-full gap-2 overflow-hidden overflow-y-auto justify-between snap-start"
 >
 	<iframe
 		src="https://www.google.com/maps/embed/v1/place?q=Ibabang+Iyam&key=AIzaSyBFw0Qbyq9zTFTd-tUY6dZWTgaQzuU17R8"

--- a/src/routes/home/hero.svelte
+++ b/src/routes/home/hero.svelte
@@ -12,7 +12,7 @@
 
 <div
   id="hero"
-  class="relative flex items-center justify-center h-full w-full snap-start pt-[25%] md:pt-[5%] overflow-hidden"
+  class="relative flex items-center justify-center h-full w-full pt-[25%] md:pt-[5%] overflow-hidden snap-start"
 >
   <div
     class="flex flex-col justify-center items-center md:items-end w-full md:w-[calc(45%-0.5rem)] h-full gap-3 md:gap-5 p-2 z-1"

--- a/src/routes/home/index.svelte
+++ b/src/routes/home/index.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Header from "@/components/header.svelte";
 	import About from "./about.svelte";
+	import Achievements from "./achievements.svelte";
 	import Hero from "./hero.svelte";
 	import Projects from "./projects.svelte";
 	import Blogs from "./blogs.svelte";
@@ -19,6 +20,7 @@
 	let categories = $state<string[]>([]);
 	let certificates = $state<Record<string, any>[]>([]);
 	let experiences = $state<Record<string, any>[]>([]);
+	let achievements = $state<Record<string, any>[]>([]);
 	let feedback = $state<Record<string, any>[]>([]);
 	let github = $state<Record<string, any>[]>([]);
 	let projects = $state<Record<string, any>[]>([]);
@@ -40,6 +42,7 @@
 				65: "about",
 				66: "blogs",
 				67: "contact",
+				71: "achievements",
 				72: "hero",
 				80: "projects",
 			};
@@ -126,6 +129,7 @@
 			projects={github}
 			expr={experiences}
 			{blogs}
+			{achievements}
 			parseData={loaded}
 		/>
 	</div>

--- a/src/routes/home/projects.svelte
+++ b/src/routes/home/projects.svelte
@@ -19,15 +19,35 @@
 
 	function filter(category: string) {
 		active = category.toLowerCase();
-		projects = totalProjects.filter((proj: Record<string, any>) =>
-			active === "all" ? true : proj.category.includes(active.toLowerCase()),
-		);
+		if (active === "all") {
+			const withImg = totalProjects.filter((p: Record<string, any>) => p.img);
+			const shuffled = [...withImg].sort(() => 0.5 - Math.random());
+			projects = shuffled
+				.slice(0, 8)
+				.sort((a: Record<string, any>, b: Record<string, any>) =>
+					a.name.localeCompare(b.name),
+				);
+		} else {
+			projects = totalProjects
+				.filter((proj: Record<string, any>) =>
+					proj.category.includes(active.toLowerCase()),
+				)
+				.sort((a: Record<string, any>, b: Record<string, any>) =>
+					a.name.localeCompare(b.name),
+				);
+		}
 	}
+
+	$effect(() => {
+		if (parseData && active === "all" && totalProjects.length > 0) {
+			filter("all");
+		}
+	});
 </script>
 
 <div
 	id="projects"
-	class="flex flex-col p-2 pt-[25%] md:pt-[10%] h-full w-full overflow-y-auto snap-start select-none"
+	class="flex flex-col p-2 pt-[25%] md:pt-[10%] h-full w-full overflow-y-auto select-none snap-start"
 >
 	<div
 		class="flex gap-2 items-center md:justify-center py-10 md:p-3 overflow-hidden overflow-x-auto scrollbar-none"
@@ -45,8 +65,9 @@
 			>
 				{#if category.length <= 3 && category !== "all"}
 					{category.toUpperCase()}
-				{:else}
-					{category[0].toUpperCase()}{category.substring(1)}
+				{:else if category === "all"}
+					Randomized
+				{:else}{category[0].toUpperCase()}{category.substring(1)}
 				{/if}
 			</li>
 		{/each}
@@ -54,47 +75,27 @@
 	<div class="flex flex-wrap w-full gap-5 p-5">
 		{#if projects.length > 0}
 			{#each projects as project}
-				{#if active.toLowerCase() === "all" && project.img}
-					<Card
-						onclick={() => {
-							window.open(project.link, "_blank");
-						}}
-						class="relative aspect-video w-full md:w-[calc(33.333%-1rem)] rounded overflow-hidden !p-0 group"
+				<Card
+					onclick={() => {
+						window.open(project.link, "_blank");
+					}}
+					class="relative aspect-video w-full md:w-[calc(25%-1rem)] rounded overflow-hidden !p-0 group"
+				>
+					<img
+						class="absolute w-full h-full md:grayscale group-hover:grayscale-0"
+						src={retrieval("retrieve", { file: project.img ?? "" })}
+						alt=""
+					/>
+					<span
+						class="absolute z-1 bottom-0 left-0 right-0 bg-[#212121]/50 text-white p-2 md:opacity-0 dark:group-hover:opacity-100 group-hover:opacity-100 transition-opacity delay-75"
 					>
-						<img
-							class="absolute w-full h-full md:grayscale group-hover:grayscale-0"
-							src={retrieval("retrieve", { file: project.img ?? "" })}
-							alt=""
-						/>
-						<span
-							class="absolute z-1 bottom-0 left-0 right-0 bg-[#212121]/50 text-white p-2 md:opacity-0 group-hover:opacity-100 transition-opacity delay-75"
-						>
-							{project.name}
-						</span>
-					</Card>
-				{:else if active.toLowerCase() !== "all"}
-					<Card
-						onclick={() => {
-							window.open(project.link, "_blank");
-						}}
-						class="relative aspect-video w-full md:w-[calc(33.333%-1rem)] rounded overflow-hidden !p-0 group"
-					>
-						<img
-							class="absolute w-full h-full md:grayscale group-hover:grayscale-0"
-							src={retrieval("retrieve", { file: project.img ?? "" })}
-							alt=""
-						/>
-						<span
-							class="absolute z-1 bottom-0 left-0 right-0 bg-[#212121]/50 text-white p-2 md:opacity-0 dark:group-hover:opacity-100 group-hover:opacity-100 transition-opacity delay-75"
-						>
-							{project.name}
-						</span>
-					</Card>
-				{/if}
+						{project.name}
+					</span>
+				</Card>
 			{/each}
 		{:else}
 			{#each Array(6) as _, i (i)}
-				<Loader class="aspect-video w-full md:w-[calc(33.333%-1rem)]"></Loader>
+				<Loader class="aspect-video w-full md:w-[calc(25%-1rem)]"></Loader>
 			{/each}
 		{/if}
 	</div>

--- a/src/routes/user/blog.svelte
+++ b/src/routes/user/blog.svelte
@@ -24,7 +24,7 @@
 </script>
 
 <div
-	class="flex flex-wrap p-2 w-full h-full gap-2 overflow-hidden overflow-y-auto snap-start pt-[5%]"
+	class="flex flex-wrap p-2 w-full h-full gap-2 overflow-hidden overflow-y-auto pt-[5%]"
 >
 	<HomeButton title={blog.title} description={blog.content} past="/blogs" />
 	<div class="w-full h-full overflow-hidden px-5">

--- a/src/routes/user/blogs.svelte
+++ b/src/routes/user/blogs.svelte
@@ -31,7 +31,7 @@
 
 <div
 	id="blogs"
-	class="flex flex-col w-full h-full gap-2 overflow-hidden overflow-y-auto snap-start"
+	class="flex flex-col w-full h-full gap-2 overflow-hidden overflow-y-auto"
 >
 	<HomeButton title="Blogs Lists" />
 	<div class="flex flex-wrap p-5 gap-5 py-[5%] w-full h-full">

--- a/src/routes/user/certificates.svelte
+++ b/src/routes/user/certificates.svelte
@@ -36,7 +36,7 @@
 </script>
 
 <div
-	class="flex flex-wrap p-2 w-full h-full gap-2 overflow-hidden overflow-y-auto snap-start pt-[5%]"
+	class="flex flex-wrap p-2 w-full h-full gap-2 overflow-hidden overflow-y-auto pt-[5%]"
 >
 	<HomeButton
 		title="Certificates"


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Randomize “All” projects view and plumb achievements into AI profile
<code>✨ Enhancement</code> <code>🐞 Bug fix</code> <code>🕐 20-40 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>Description</summary>

<br/>

<pre>
• Randomize the “All” projects category and standardize sorting for filtered categories.
• Add an achievements data prop and include it in the AI dev profile context.
• Fix several route layouts by switching to <b><i>h-full</i></b> / adjusting <b><i>snap-start</i></b> usage.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  Home["Home page (index)"] --> Data["Client data fetch"] --> Projects["Projects section"] --> Cards["Project cards"]
  Home --> Ai["AI widget"] --> ChatAPI[("ai/chat API")]
  Home --> Ach["Achievements section"]
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Persist a single randomized selection per page load</b></summary>

- ➕ Avoids reshuffling every time the user clicks back to “All”
- ➕ Makes the UI feel more stable/predictable while still being “random” per session
- ➖ Slightly more state management (store selected IDs / seed)
- ➖ Less variety if the intent is to reshuffle on each click

</details>

<details>
<summary><b>2. Use a deterministic seeded shuffle (e.g., by day)</b></summary>

- ➕ Reproducible “randomized” ordering for easier debugging and consistent UX
- ➕ Can change daily/weekly without being noisy
- ➖ Adds a seed concept and a shuffle implementation
- ➖ May not match the desired fully-random behavior

</details>

<details>
<summary><b>3. Fully implement achievements end-to-end before wiring into AI</b></summary>

- ➕ Prevents dead/empty props and placeholder sections
- ➕ Ensures AI prompt data matches visible site content
- ➖ Bigger PR; couples UI + data contract + backend changes together

</details>

**Recommendation:** Current approach is fine for quickly improving the “All” projects experience and preparing AI context. Consider persisting or seeding the randomized selection to avoid re-randomization surprises, and either load achievements data (and render the Achievements section) or defer wiring until the data source exists to keep the home page state model tight.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (3)</summary>

<blockquote>
<details>
<summary><strong>ai.svelte</strong> <code>Add achievements into AI dev profile context</code> <code>+2/-0</code></summary>

<br/>

>Add achievements into AI dev profile context
>
><pre>
>• Adds an &#x27;achievements&#x27; prop and includes it in the derived &#x27;devProfile&#x27; object used to build the AI system prompt.
></pre>
>
><a href='https://github.com/RyannKim327/ryannkim327.github.io/pull/59/files#diff-06e18ec14b8178bd545d9e303666b75a5e33652d604e7eca150526e112983eb9'>src/components/ai.svelte</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>index.svelte</strong> <code>Wire achievements state and pass into AI widget</code> <code>+4/-0</code></summary>

<br/>

>Wire achievements state and pass into AI widget
>
><pre>
>• Imports the achievements route component (not yet rendered), adds &#x27;achievements&#x27; state, adds a keyboard shortcut mapping for an achievements anchor, and passes &#x27;achievements&#x27; into the AI component props.
></pre>
>
><a href='https://github.com/RyannKim327/ryannkim327.github.io/pull/59/files#diff-99dd0f129f946c65c4fd6bb8576d2cbecf7d879b55ec11679a2ead9f0e3191b8'>src/routes/home/index.svelte</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>projects.svelte</strong> <code>Randomize “All” projects and standardize sorting/rendering</code> <code>+44/-43</code></summary>

<br/>

>Randomize “All” projects and standardize sorting/rendering
>
><pre>
>• Changes the “all” filter to pick a randomized subset of image-backed projects (up to 8) and then sort by name; other categories are filtered and name-sorted. Adds an effect to initialize the randomized set once data is loaded, updates the “all” label to “Randomized”, and adjusts card/skeleton widths to a 4-column layout on desktop.
></pre>
>
><a href='https://github.com/RyannKim327/ryannkim327.github.io/pull/59/files#diff-4c60598007f3a582dae494734e27c663db3986b82dbf7f279ecfa12b908077e1'>src/routes/home/projects.svelte</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Bug fix</strong> (6)</summary>

<blockquote>
<details>
<summary><strong>contact.svelte</strong> <code>Adjust admin contact page container height behavior</code> <code>+1/-1</code></summary>

<br/>

>Adjust admin contact page container height behavior
>
><pre>
>• Replaces &#x27;min-h-screen&#x27; with &#x27;h-full&#x27; on the outer container to better fit parent-controlled layouts.
></pre>
>
><a href='https://github.com/RyannKim327/ryannkim327.github.io/pull/59/files#diff-d936a6f423385bf0074dbe5986668e836bc8c6743fa9a099fbf648c2db7dd127'>src/routes/admin/contact.svelte</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>info.svelte</strong> <code>Adjust admin info page container height behavior</code> <code>+1/-1</code></summary>

<br/>

>Adjust admin info page container height behavior
>
><pre>
>• Replaces &#x27;min-h-screen&#x27; with &#x27;h-full&#x27; on the outer container to avoid forcing viewport min-height.
></pre>
>
><a href='https://github.com/RyannKim327/ryannkim327.github.io/pull/59/files#diff-d30fe15272843bbddacc878d1cb597b7c54043a8568ed5c2498082f04f33e92d'>src/routes/admin/info.svelte</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>upload.svelte</strong> <code>Adjust admin upload page container height behavior</code> <code>+1/-1</code></summary>

<br/>

>Adjust admin upload page container height behavior
>
><pre>
>• Replaces &#x27;min-h-screen&#x27; with &#x27;h-full&#x27; on the outer container for consistent sizing within the admin shell.
></pre>
>
><a href='https://github.com/RyannKim327/ryannkim327.github.io/pull/59/files#diff-47c1afb8f3d035b2e8e97e80e5854a425a9084de9fc3f1798db069e0b3163ba3'>src/routes/admin/upload.svelte</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>blog.svelte</strong> <code>Remove snap-start from user blog view container</code> <code>+1/-1</code></summary>

<br/>

>Remove snap-start from user blog view container
>
><pre>
>• Drops &#x27;snap-start&#x27; from the blog page wrapper to change scroll snapping behavior in this route.
></pre>
>
><a href='https://github.com/RyannKim327/ryannkim327.github.io/pull/59/files#diff-a15e349a21b09d3b34ec89949582176882da74b80cf6517fdcb3d361ad70a769'>src/routes/user/blog.svelte</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>blogs.svelte</strong> <code>Remove snap-start from blogs list container</code> <code>+1/-1</code></summary>

<br/>

>Remove snap-start from blogs list container
>
><pre>
>• Drops &#x27;snap-start&#x27; from the blogs list wrapper, likely to prevent unintended snap behavior in nested scroll contexts.
></pre>
>
><a href='https://github.com/RyannKim327/ryannkim327.github.io/pull/59/files#diff-c28b9ddc736d4419254f80cf91c4ab9a5d8486739dfb9bf291144265698cf25f'>src/routes/user/blogs.svelte</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>certificates.svelte</strong> <code>Remove snap-start from certificates view container</code> <code>+1/-1</code></summary>

<br/>

>Remove snap-start from certificates view container
>
><pre>
>• Drops &#x27;snap-start&#x27; from the certificates page wrapper to align scrolling behavior with other user routes.
></pre>
>
><a href='https://github.com/RyannKim327/ryannkim327.github.io/pull/59/files#diff-93e5aa3e1ae485f550ba1783f69df3414978d30aea144a742033d2d24e47a698'>src/routes/user/certificates.svelte</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Refactor</strong> (3)</summary>

<blockquote>
<details>
<summary><strong>achievements.svelte</strong> <code>Tidy achievements route scaffold</code> <code>+0/-1</code></summary>

<br/>

>Tidy achievements route scaffold
>
><pre>
>• Removes an extra blank line in the empty script block; the route remains a placeholder container.
></pre>
>
><a href='https://github.com/RyannKim327/ryannkim327.github.io/pull/59/files#diff-a2c18386a74745af966e55b72629079a4cb09ccecdd6556e4584c18319a56636'>src/routes/home/achievements.svelte</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>contact.svelte</strong> <code>Reorder snap class in contact section container</code> <code>+1/-1</code></summary>

<br/>

>Reorder snap class in contact section container
>
><pre>
>• Reorders &#x27;snap-start&#x27; within the class string (no functional change expected) to match other sections’ class ordering.
></pre>
>
><a href='https://github.com/RyannKim327/ryannkim327.github.io/pull/59/files#diff-b0e7c3a67046206fdbc8576a7a1787604336f68eb26142c8a3dd310b43ae641a'>src/routes/home/contact.svelte</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>hero.svelte</strong> <code>Reorder snap class in hero section container</code> <code>+1/-1</code></summary>

<br/>

>Reorder snap class in hero section container
>
><pre>
>• Reorders &#x27;snap-start&#x27; within the hero container class list for consistency.
></pre>
>
><a href='https://github.com/RyannKim327/ryannkim327.github.io/pull/59/files#diff-39ac38ead9e0133725bd92daf3a725b8b5ce7bf65459d23c1dca19e44ed806d7'>src/routes/home/hero.svelte</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>